### PR TITLE
Remove class parameters (deprecated practice)

### DIFF
--- a/Resources/config/actions.xml
+++ b/Resources/config/actions.xml
@@ -4,55 +4,37 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-        <!-- Action classes -->
-        <parameter key="elao_rest_action.action.class">Elao\Bundle\RestActionBundle\Action\Action</parameter>
-        <parameter key="elao_rest_action.action.list.class">Elao\Bundle\RestActionBundle\Action\ListAction</parameter>
-        <parameter key="elao_rest_action.action.create.class">Elao\Bundle\RestActionBundle\Action\CreateAction</parameter>
-        <parameter key="elao_rest_action.action.read.class">Elao\Bundle\RestActionBundle\Action\ReadAction</parameter>
-        <parameter key="elao_rest_action.action.update.class">Elao\Bundle\RestActionBundle\Action\UpdateAction</parameter>
-        <parameter key="elao_rest_action.action.delete.class">Elao\Bundle\RestActionBundle\Action\DeleteAction</parameter>
-
-        <!-- Action configuration classes -->
-        <parameter key="elao_rest_action.action_configuration.list.class">Elao\Bundle\RestActionBundle\DependencyInjection\ActionConfiguration\ListActionConfiguration</parameter>
-        <parameter key="elao_rest_action.action_configuration.create.class">Elao\Bundle\RestActionBundle\DependencyInjection\ActionConfiguration\CreateActionConfiguration</parameter>
-        <parameter key="elao_rest_action.action_configuration.read.class">Elao\Bundle\RestActionBundle\DependencyInjection\ActionConfiguration\ReadActionConfiguration</parameter>
-        <parameter key="elao_rest_action.action_configuration.update.class">Elao\Bundle\RestActionBundle\DependencyInjection\ActionConfiguration\UpdateActionConfiguration</parameter>
-        <parameter key="elao_rest_action.action_configuration.delete.class">Elao\Bundle\RestActionBundle\DependencyInjection\ActionConfiguration\DeleteActionConfiguration</parameter>
-    </parameters>
-
     <services>
         <!-- REST action -->
-        <service id="elao_rest_action.action" class="%elao_rest_action.action.class%" parent="elao_admin.action" abstract="true">
-        </service>
+        <service id="elao_rest_action.action" class="Elao\Bundle\RestActionBundle\Action\Action" parent="elao_admin.action" abstract="true"/>
 
         <!-- List action -->
-        <service id="elao_rest_action.action.list" class="%elao_rest_action.action.list.class%" parent="elao_rest_action.action" abstract="true">
-            <tag name="elao_admin.action" alias="list" configuration="%elao_rest_action.action_configuration.list.class%"/>
+        <service id="elao_rest_action.action.list" class="Elao\Bundle\RestActionBundle\Action\ListAction" parent="elao_rest_action.action" abstract="true">
+            <tag name="elao_admin.action" alias="list" configuration="Elao\Bundle\RestActionBundle\DependencyInjection\ActionConfiguration\ListActionConfiguration"/>
             <argument type="service" id="form.factory" />
             <argument type="service" id="knp_paginator" />
         </service>
 
         <!-- Create action -->
-        <service id="elao_rest_action.action.create" class="%elao_rest_action.action.create.class%" parent="elao_rest_action.action" abstract="true">
-            <tag name="elao_admin.action" alias="create" configuration="%elao_rest_action.action_configuration.create.class%"/>
+        <service id="elao_rest_action.action.create" class="Elao\Bundle\RestActionBundle\Action\CreateAction" parent="elao_rest_action.action" abstract="true">
+            <tag name="elao_admin.action" alias="create" configuration="Elao\Bundle\RestActionBundle\DependencyInjection\ActionConfiguration\CreateActionConfiguration"/>
             <argument type="service" id="form.factory" />
         </service>
 
         <!-- Read action -->
-        <service id="elao_rest_action.action.read" class="%elao_rest_action.action.read.class%" parent="elao_rest_action.action" abstract="true">
-            <tag name="elao_admin.action" alias="read" configuration="%elao_rest_action.action_configuration.read.class%"/>
+        <service id="elao_rest_action.action.read" class="Elao\Bundle\RestActionBundle\Action\ReadAction" parent="elao_rest_action.action" abstract="true">
+            <tag name="elao_admin.action" alias="read" configuration="Elao\Bundle\RestActionBundle\DependencyInjection\ActionConfiguration\ReadActionConfiguration"/>
         </service>
 
         <!-- Update action -->
-        <service id="elao_rest_action.action.update" class="%elao_rest_action.action.update.class%" parent="elao_rest_action.action" abstract="true">
-            <tag name="elao_admin.action" alias="update" configuration="%elao_rest_action.action_configuration.update.class%"/>
+        <service id="elao_rest_action.action.update" class="Elao\Bundle\RestActionBundle\Action\UpdateAction" parent="elao_rest_action.action" abstract="true">
+            <tag name="elao_admin.action" alias="update" configuration="Elao\Bundle\RestActionBundle\DependencyInjection\ActionConfiguration\UpdateActionConfiguration"/>
             <argument type="service" id="form.factory" />
         </service>
 
         <!-- Delete action -->
-        <service id="elao_rest_action.action.delete" class="%elao_rest_action.action.delete.class%" parent="elao_rest_action.action" abstract="true">
-            <tag name="elao_admin.action" alias="delete" configuration="%elao_rest_action.action_configuration.delete.class%"/>
+        <service id="elao_rest_action.action.delete" class="Elao\Bundle\RestActionBundle\Action\DeleteAction" parent="elao_rest_action.action" abstract="true">
+            <tag name="elao_admin.action" alias="delete" configuration="Elao\Bundle\RestActionBundle\DependencyInjection\ActionConfiguration\DeleteActionConfiguration"/>
             <argument type="service" id="form.factory" />
         </service>
     </services>


### PR DESCRIPTION
As mentioned in [the symfony doc](http://symfony.com/doc/current/best_practices/business-logic.html#service-no-class-parameter), it's a best practice to don't define class parameters.

Except if there is a real value of having these parameters, we should remove them.
